### PR TITLE
multi-row select!

### DIFF
--- a/src/Logazmic/Views/LogPaneView.xaml
+++ b/src/Logazmic/Views/LogPaneView.xaml
@@ -69,7 +69,7 @@
         <DataGrid x:Name="LogDataGrid" ItemsSource="{Binding Path=CollectionViewSource.View}"
                   SelectedItem="{Binding Path=SelectedLogMessage}" AutoGenerateColumns="False"
                   CanUserAddRows="False" CanUserDeleteRows="False" CanUserReorderColumns="False"
-                  CanUserResizeRows="False" SelectionMode="Single"
+                  CanUserResizeRows="False" SelectionMode="Extended"
                   GridLinesVisibility="{Binding  Source={x:Static settings:LogazmicSettings.Instance}, Path=GridLinesVisibility}"
                   FontSize="{Binding Source={x:Static settings:LogazmicSettings.Instance}, Path=GridFontSize}"
                   CellStyle="{StaticResource CellStyle}" RowStyle="{StaticResource RowStyle}"


### PR DESCRIPTION
- [CTRL + Click] to select/deselect additional rows
- [SHIFT + Click] to select multi row from first selected row to newly selected row
- closes my wishlist feature https://github.com/0xDE57/Logazmic/issues/2

Quality of life improvement for copy pasting multiple rows.

Without multirow select, my workaround is to copy all rows via the copy to clipboard button, then paste into notepad++ and manually remove the unwanted rows. This solves that pain point by allowing native multi-select just like other native windows behavior (such as file explorer)